### PR TITLE
Make json a function call

### DIFF
--- a/export.py
+++ b/export.py
@@ -162,7 +162,7 @@ class Bitly(object):
         if http_response.status_code != 200:
             raise Exception('HTTP %d Error: %s' % (http_response.status_code, http_response.text))
         
-        data = http_response.json
+        data = http_response.json()
         
         if data is None or data.get('status_code', 500) != 200:
             raise Exception('Bitly returned error code %d: %s' % (data.get('status_code', 500), data.get('status_txt', 'UNKNOWN_ERROR')))


### PR DESCRIPTION
Requests changed `json` to a function call a while ago (see http://docs.python-requests.org/en/latest/api/#migrating-to-1-x). I just made it into a function call locally, and it worked like a charm!

PS: Thanks a lot for this script, after the bitly security thing I wanted to grab my data and anonymize my account; this worked perfectly for grabbing my data.
